### PR TITLE
Fixing memory leak transferring dictionary to ARC

### DIFF
--- a/InstallerLauncher/SUInstallerLauncher.m
+++ b/InstallerLauncher/SUInstallerLauncher.m
@@ -152,7 +152,7 @@
                 size_t imageCount = CGImageSourceGetCount(imageSource);
                 for (size_t imageIndex = 0; imageIndex < imageCount; imageIndex++) {
                     CFDictionaryRef cfProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, imageIndex, (CFDictionaryRef)@{});
-                    NSDictionary *properties = (__bridge NSDictionary *)(cfProperties);
+                    NSDictionary *properties = CFBridgingRelease(cfProperties);
                     
                     NSNumber *pixelWidth = properties[(const NSString *)kCGImagePropertyPixelWidth];
                     NSNumber *pixelHeight = properties[(const NSString *)kCGImagePropertyPixelHeight];


### PR DESCRIPTION
Assigning to `properties` will cause ARC to retain the dictionary, but that dictionary is already retained when returned from `CGImageSourceCopyPropertiesAtIndex`. So we need to either `CFRelease` the CF variable afterward, or use `CFBridgingRelease` to explicitly transfer ownership to ARC.

Caught using the static analyser.
