### PR TITLE
Fixed retain cycle between SPUBasicUpdateDriver and SUAppcastDriver

### DIFF
--- a/Sparkle/SUAppcastDriver.m
+++ b/Sparkle/SUAppcastDriver.m
@@ -27,7 +27,7 @@
 @property (nullable, nonatomic, readonly, weak) id updater;
 @property (nullable, nonatomic, readonly, weak) id <SPUUpdaterDelegate> updaterDelegate;
 @property (nullable, nonatomic) SUAppcastItem *nonDeltaUpdateItem;
-@property (nullable, nonatomic, readonly) id <SUAppcastDriverDelegate> delegate;
+@property (nullable, nonatomic, readonly, weak) id <SUAppcastDriverDelegate> delegate;
 
 @end
 


### PR DESCRIPTION
Fixes a leak that occurred during each update check.